### PR TITLE
Publish evidence-first portfolio and public work ledger

### DIFF
--- a/docs/EVIDENCE_OF_WORK.md
+++ b/docs/EVIDENCE_OF_WORK.md
@@ -1,0 +1,126 @@
+# Public Evidence of Work Ledger
+
+This ledger records public, verifiable evidence of work by A. C. Van Cura under the GitHub account `TheAVCfiles`.
+
+## Governing rule
+
+> The relationship explains access. The record establishes contribution.
+
+The purpose of this document is attribution without overstatement. It distinguishes public technical proof from private correspondence, informal apprenticeship, employment claims, and third-party outcomes.
+
+## Evidence classes
+
+| Class | Meaning |
+|---|---|
+| A | Dated commit, merged pull request, or released source code |
+| B | Live public demo or deployed interface |
+| C | Architecture, README, testing record, schema, or operational documentation |
+| D | Private supporting record held outside the public repository |
+
+## Selected evidence
+
+### 1. StagePort x CueR
+
+**Public claim:** Designed and built a scoped multi-agent live-event system that reads synthetic room context, proposes access or introduction actions, preserves human approval, and records approved actions as receipts and keychain memory.
+
+**Evidence:**
+
+- Class A: Public repository and commit history
+- Class B: Live Replit demonstration
+- Class C: README, founder origin, architecture, testing, submission, and IP-boundary documentation
+
+**Links:**
+
+- Repository: https://github.com/TheAVCfiles/stageport-cuer-hackathon
+- README: https://github.com/TheAVCfiles/stageport-cuer-hackathon/blob/main/README.md
+- Founder origin: https://github.com/TheAVCfiles/stageport-cuer-hackathon/blob/main/FOUNDER_ORIGIN.md
+- Live demo: https://stageportxcuer.replit.app/
+
+**Boundary:** The public repository uses synthetic evaluation data and does not expose production StagePort infrastructure, customer data, signing keys, private scoring logic, or unreleased StudioOS methodology.
+
+### 2. StagePort CueRoom
+
+**Public claim:** Built a bounded education agent that converts movement vocabulary, counts, music cues, learning objectives, and constraints into a structured choreography-room proposal with strict tools, visible traces, human approval, and SHA-256 proof receipts.
+
+**Evidence:**
+
+- Class A: Merged pull request and merge commit
+- Class B: Deployed Vercel demonstration
+- Class C: Verification notes, schema boundaries, testing results, and submission materials
+
+**Links:**
+
+- Pull request: https://github.com/TheAVCfiles/stageport-cuer-hackathon/pull/1
+- Merge commit: https://github.com/TheAVCfiles/stageport-cuer-hackathon/commit/cba9f74a860c83042b0a7a296db8a7fe8908f709
+- Live demo: https://stageport-cueroom-build-week.vercel.app/
+
+### 3. StagePort PayGait
+
+**Public claim:** Developed a starter package for consent-based SentientCents-to-Stagecoin conversion using an EIP-712 signing flow, gas-sponsored relayer, role-controlled smart contracts, royalty logic, React client, and operational deployment documentation.
+
+**Evidence:**
+
+- Class A: Merged pull request containing code and tests
+- Class C: Operational notes, quick-start documentation, role controls, security cautions, and production-hardening boundaries
+
+**Links:**
+
+- Pull request: https://github.com/TheAVCfiles/codex/pull/223
+- Merge commit: https://github.com/TheAVCfiles/codex/commit/136aa004d2f3a399f770ab6388b859a89bbffaee
+
+**Boundary:** The pull request explicitly records that syntax checks passed, while full Hardhat integration testing and production deployment were not completed in that run. Public claims should preserve that distinction.
+
+### 4. Holiday Activity: Choreographic Rights Management
+
+**Public claim:** Built a decentralized prototype that translates choreographic rights into smart-contract roles, royalties, Stagecoin and SentientCents primitives, and a React movement-claim interface.
+
+**Evidence:**
+
+- Class A: Public contracts, frontend code, tests, commits, and merged feature work
+- Class C: README and documented project structure
+
+**Links:**
+
+- Repository: https://github.com/TheAVCfiles/Holiday-Activity
+- README: https://github.com/TheAVCfiles/Holiday-Activity/blob/main/README.md
+- Initial implementation: https://github.com/TheAVCfiles/Holiday-Activity/commit/e051171791152c5d1e40c3b9d8cbc428173b9bd7
+- Feature completion: https://github.com/TheAVCfiles/Holiday-Activity/commit/4f5b35caae29a68697c234b1cacea5cd1995060f
+
+### 5. Decrypt The Girl
+
+**Public claim:** Authored and implemented an interactive poetic codebook that combines narrative systems, responsive web interaction, accessible navigation patterns, market-oriented interfaces, telemetry, and automated deployment.
+
+**Evidence:**
+
+- Class A: Public source repository and development history
+- Class B: Deployed GitHub Pages experience
+- Class C: README, architecture notes, CI workflows, contribution guidance, and change history
+
+**Links:**
+
+- Repository: https://github.com/TheAVCfiles/Decrypt-The-Girl
+- README: https://github.com/TheAVCfiles/Decrypt-The-Girl/blob/main/README.md
+- Live experience: https://theavcfiles.github.io/Decrypt-The-Girl/
+- GitHub Actions: https://github.com/TheAVCfiles/Decrypt-The-Girl/actions
+
+## Public claim exclusions
+
+This ledger does not claim:
+
+- employment where the work was an informal collaboration or apprenticeship
+- ownership of third-party company materials
+- responsibility for acquisitions, funding events, or outcomes not directly evidenced
+- production readiness where the record supports only a prototype or starter implementation
+- privacy-sensitive correspondence, client records, credentials, keys, or proprietary systems
+
+## Private evidence protocol
+
+Private records may support future portfolio statements but should not be published by default. Preserve:
+
+- original email files and headers
+- source attachments and version history
+- timestamps and file metadata
+- exact requests and defined contribution ranges
+- public-claim language and confidentiality restrictions
+
+The public portfolio should disclose the minimum evidence needed to establish authorship, capability, and chronology without exposing another party's private material.

--- a/public/evidence-of-work.html
+++ b/public/evidence-of-work.html
@@ -1,0 +1,369 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Verified public evidence of systems, software, product architecture, and technical storytelling by A. C. Van Cura.">
+  <title>Evidence of Work | A. C. Van Cura</title>
+  <style>
+    :root {
+      --ink: #111827;
+      --muted: #4b5563;
+      --paper: #f7f7f4;
+      --card: #ffffff;
+      --line: #d7d9dd;
+      --accent: #6d28d9;
+      --accent-soft: #ede9fe;
+      --proof: #166534;
+      --proof-soft: #dcfce7;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      background: var(--paper);
+      color: var(--ink);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.6;
+    }
+
+    a { color: var(--accent); }
+    a:hover { text-decoration-thickness: 2px; }
+
+    .shell {
+      width: min(1080px, calc(100% - 32px));
+      margin: 0 auto;
+    }
+
+    header {
+      padding: 56px 0 28px;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .eyebrow {
+      margin: 0 0 10px;
+      font-size: 0.82rem;
+      font-weight: 800;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--accent);
+    }
+
+    h1 {
+      max-width: 800px;
+      margin: 0;
+      font-size: clamp(2.3rem, 6vw, 4.8rem);
+      line-height: 1.02;
+      letter-spacing: -0.04em;
+    }
+
+    .lede {
+      max-width: 790px;
+      margin: 22px 0 0;
+      font-size: clamp(1.05rem, 2vw, 1.35rem);
+      color: var(--muted);
+    }
+
+    .doctrine {
+      margin: 28px 0 0;
+      padding: 18px 20px;
+      border-left: 5px solid var(--accent);
+      background: var(--accent-soft);
+      font-weight: 750;
+      font-size: 1.04rem;
+    }
+
+    main { padding: 38px 0 72px; }
+
+    section { margin-top: 50px; }
+    section:first-child { margin-top: 0; }
+
+    h2 {
+      margin: 0 0 18px;
+      font-size: clamp(1.55rem, 3vw, 2.2rem);
+      letter-spacing: -0.025em;
+    }
+
+    .standards {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+      gap: 14px;
+    }
+
+    .standard,
+    .project {
+      background: var(--card);
+      border: 1px solid var(--line);
+      border-radius: 16px;
+    }
+
+    .standard { padding: 18px; }
+    .standard strong { display: block; margin-bottom: 6px; }
+    .standard p { margin: 0; color: var(--muted); }
+
+    .projects {
+      display: grid;
+      gap: 20px;
+    }
+
+    .project { padding: 24px; }
+
+    .project-head {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 18px;
+      flex-wrap: wrap;
+    }
+
+    .project h3 {
+      margin: 0;
+      font-size: 1.42rem;
+      letter-spacing: -0.02em;
+    }
+
+    .status {
+      display: inline-flex;
+      align-items: center;
+      padding: 5px 10px;
+      border-radius: 999px;
+      background: var(--proof-soft);
+      color: var(--proof);
+      font-size: 0.78rem;
+      font-weight: 850;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
+
+    .summary {
+      max-width: 850px;
+      margin: 12px 0 0;
+      color: var(--muted);
+    }
+
+    .claim {
+      margin: 18px 0 0;
+      padding: 14px 16px;
+      border-radius: 12px;
+      background: #f3f4f6;
+    }
+
+    .claim strong { display: block; margin-bottom: 3px; }
+
+    .evidence {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-top: 18px;
+    }
+
+    .evidence a {
+      display: inline-flex;
+      align-items: center;
+      min-height: 40px;
+      padding: 8px 12px;
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      background: #fff;
+      font-weight: 750;
+      text-decoration: none;
+    }
+
+    .evidence a:hover {
+      border-color: var(--accent);
+      background: var(--accent-soft);
+    }
+
+    .boundary {
+      padding: 24px;
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      background: #111827;
+      color: #f9fafb;
+    }
+
+    .boundary h2 { color: #fff; }
+    .boundary p, .boundary li { color: #d1d5db; }
+    .boundary ul { margin-bottom: 0; }
+
+    footer {
+      padding: 24px 0 44px;
+      border-top: 1px solid var(--line);
+      color: var(--muted);
+      font-size: 0.92rem;
+    }
+
+    .footer-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+
+    @media (max-width: 640px) {
+      header { padding-top: 38px; }
+      .project { padding: 20px; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="shell">
+      <p class="eyebrow">Public Evidence Portfolio</p>
+      <h1>Evidence of Work</h1>
+      <p class="lede">
+        A verifiable record of systems architecture, software prototypes, product logic, technical communication, and founder-built infrastructure by A. C. Van Cura.
+      </p>
+      <p class="doctrine">The relationship explains access. The record establishes contribution.</p>
+    </div>
+  </header>
+
+  <main class="shell">
+    <section aria-labelledby="standard-title">
+      <h2 id="standard-title">Evidence standard</h2>
+      <div class="standards">
+        <article class="standard">
+          <strong>Code</strong>
+          <p>Public source, repository structure, schemas, tests, and implementation artifacts.</p>
+        </article>
+        <article class="standard">
+          <strong>Commit history</strong>
+          <p>Dated commits and merged pull requests that preserve development sequence.</p>
+        </article>
+        <article class="standard">
+          <strong>Live proof</strong>
+          <p>Public demos or deployed interfaces that allow direct inspection.</p>
+        </article>
+        <article class="standard">
+          <strong>Boundaries</strong>
+          <p>Explicit limits on what each artifact proves and what remains private.</p>
+        </article>
+      </div>
+    </section>
+
+    <section aria-labelledby="selected-title">
+      <h2 id="selected-title">Selected verified work</h2>
+      <div class="projects">
+        <article class="project">
+          <div class="project-head">
+            <h3>StagePort x CueR: Operational Memory for Live Event Rooms</h3>
+            <span class="status">Public and deployed</span>
+          </div>
+          <p class="summary">
+            A multi-agent live-event access and introduction system. CueR reads synthetic room context, pass tier, participant intent, zone pressure, and operational state, then proposes actions for a human director to approve. Approved actions become receipt and keychain artifacts.
+          </p>
+          <div class="claim">
+            <strong>What this proves</strong>
+            Product thesis, systems architecture, human-in-the-loop governance, public-safe data boundaries, agent interfaces, receipt logic, deployment planning, and technical documentation.
+          </div>
+          <div class="evidence">
+            <a href="https://github.com/TheAVCfiles/stageport-cuer-hackathon">Repository</a>
+            <a href="https://github.com/TheAVCfiles/stageport-cuer-hackathon/blob/main/README.md">Technical README</a>
+            <a href="https://github.com/TheAVCfiles/stageport-cuer-hackathon/blob/main/FOUNDER_ORIGIN.md">Founder origin</a>
+            <a href="https://stageportxcuer.replit.app/">Live demo</a>
+            <a href="https://github.com/TheAVCfiles/stageport-cuer-hackathon/commits/main">Commit history</a>
+          </div>
+        </article>
+
+        <article class="project">
+          <div class="project-head">
+            <h3>StagePort CueRoom: Education Agent with Human Approval</h3>
+            <span class="status">Merged PR and deployed</span>
+          </div>
+          <p class="summary">
+            A bounded education-track agent that turns movement vocabulary, counts, music cues, learning objectives, and constraints into a structured choreography-room proposal. The implementation uses strict tools, visible tool traces, a separate human decision gate, and SHA-256 proof receipts.
+          </p>
+          <div class="claim">
+            <strong>What this proves</strong>
+            Structured AI tool use, strict schema design, teacher-facing UX, test discipline, explicit approval boundaries, cryptographic receipt generation, and public submission packaging.
+          </div>
+          <div class="evidence">
+            <a href="https://github.com/TheAVCfiles/stageport-cuer-hackathon/pull/1">Merged pull request</a>
+            <a href="https://stageport-cueroom-build-week.vercel.app/">Live demo</a>
+            <a href="https://github.com/TheAVCfiles/stageport-cuer-hackathon/commit/cba9f74a860c83042b0a7a296db8a7fe8908f709">Merge commit</a>
+          </div>
+        </article>
+
+        <article class="project">
+          <div class="project-head">
+            <h3>StagePort PayGait: Consent, Conversion, and Royalty Infrastructure</h3>
+            <span class="status">Merged implementation</span>
+          </div>
+          <p class="summary">
+            A starter implementation for SentientCents-to-Stagecoin conversion flows using a gas-sponsored relayer, EIP-712 consent signatures, role-controlled smart contracts, royalty logic, a React signing client, deployment artifacts, and operational documentation.
+          </p>
+          <div class="claim">
+            <strong>What this proves</strong>
+            Payment and conversion architecture, smart-contract role controls, signature verification, nonce and expiry handling, relayer design, product UI, and operational hardening awareness.
+          </div>
+          <div class="evidence">
+            <a href="https://github.com/TheAVCfiles/codex/pull/223">Merged pull request</a>
+            <a href="https://github.com/TheAVCfiles/codex/commit/136aa004d2f3a399f770ab6388b859a89bbffaee">Merge commit</a>
+          </div>
+        </article>
+
+        <article class="project">
+          <div class="project-head">
+            <h3>Holiday Activity: Choreographic Rights Management</h3>
+            <span class="status">Public repository</span>
+          </div>
+          <p class="summary">
+            A decentralized prototype for choreographic rights management using Solidity contracts, role-based access control, configurable royalties, Stagecoin and SentientCents, and a React interface for movement-claim and PayGait workflows.
+          </p>
+          <div class="claim">
+            <strong>What this proves</strong>
+            Translation of choreographic rights concepts into token, royalty, permissions, frontend, testing, and deployment primitives.
+          </div>
+          <div class="evidence">
+            <a href="https://github.com/TheAVCfiles/Holiday-Activity">Repository</a>
+            <a href="https://github.com/TheAVCfiles/Holiday-Activity/blob/main/README.md">README</a>
+            <a href="https://github.com/TheAVCfiles/Holiday-Activity/commit/e051171791152c5d1e40c3b9d8cbc428173b9bd7">Implementation commit</a>
+            <a href="https://github.com/TheAVCfiles/Holiday-Activity/commit/4f5b35caae29a68697c234b1cacea5cd1995060f">Completion commit</a>
+          </div>
+        </article>
+
+        <article class="project">
+          <div class="project-head">
+            <h3>Decrypt The Girl: Interactive Poetic Codebook</h3>
+            <span class="status">Public and deployed</span>
+          </div>
+          <p class="summary">
+            A web-based interactive narrative that combines poetry, code, myth, responsive navigation, accessible interaction patterns, market-oriented interfaces, telemetry, and automated GitHub deployment.
+          </p>
+          <div class="claim">
+            <strong>What this proves</strong>
+            Original product authorship, narrative systems design, front-end implementation, interaction design, technical documentation, and long-form continuity between artistic method and software architecture.
+          </div>
+          <div class="evidence">
+            <a href="https://github.com/TheAVCfiles/Decrypt-The-Girl">Repository</a>
+            <a href="https://github.com/TheAVCfiles/Decrypt-The-Girl/blob/main/README.md">README</a>
+            <a href="https://theavcfiles.github.io/Decrypt-The-Girl/">Live experience</a>
+            <a href="https://github.com/TheAVCfiles/Decrypt-The-Girl/actions">Automation history</a>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="boundary" aria-labelledby="boundary-title">
+      <h2 id="boundary-title">Claim boundary</h2>
+      <p>This page is intentionally narrower than a full biography or private evidence archive.</p>
+      <ul>
+        <li>It does not convert informal collaboration into a false employment claim.</li>
+        <li>It does not claim causation for third-party acquisitions, funding, or institutional outcomes.</li>
+        <li>It does not publish confidential correspondence, private client work, credentials, signing keys, or proprietary production logic.</li>
+        <li>It does show public code, dated development history, deployed demonstrations, merged pull requests, and documented system boundaries.</li>
+      </ul>
+    </section>
+  </main>
+
+  <footer>
+    <div class="shell footer-row">
+      <span>A. C. Van Cura | TheAVCfiles</span>
+      <span><a href="https://github.com/TheAVCfiles">GitHub profile</a> · <a href="/">Home</a></span>
+    </div>
+  </footer>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -2,50 +2,116 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Welcome to TheAVCfiles</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Systems, software, and evidence of work by A. C. Van Cura.">
+  <title>A. C. Van Cura | Systems and Evidence</title>
   <style>
-    body { font-family: Arial, sans-serif; background: #f9f9f9; color: #222; margin: 0; padding: 0; }
-    .container { max-width: 600px; margin: 80px auto; background: #fff; border-radius: 8px; box-shadow: 0 2px 8px rgba(0,0,0,0.06); padding: 40px; }
-    h1 { font-size: 2.5em; margin-bottom: 0.5em; }
-    p { font-size: 1.2em; }
-    .footer { margin-top: 2em; color: #888; font-size: 0.9em; }
+    :root {
+      --ink: #111827;
+      --muted: #4b5563;
+      --paper: #f7f7f4;
+      --card: #ffffff;
+      --line: #d7d9dd;
+      --accent: #6d28d9;
+      --accent-soft: #ede9fe;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      padding: 24px;
+      background: var(--paper);
+      color: var(--ink);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    main {
+      width: min(820px, 100%);
+      padding: clamp(28px, 6vw, 64px);
+      border: 1px solid var(--line);
+      border-radius: 22px;
+      background: var(--card);
+      box-shadow: 0 18px 60px rgba(17, 24, 39, 0.08);
+    }
+
+    .eyebrow {
+      margin: 0 0 10px;
+      color: var(--accent);
+      font-size: 0.82rem;
+      font-weight: 850;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(2.4rem, 7vw, 5.3rem);
+      line-height: 0.98;
+      letter-spacing: -0.045em;
+    }
+
+    .lede {
+      max-width: 680px;
+      margin: 24px 0 0;
+      color: var(--muted);
+      font-size: clamp(1.08rem, 2.2vw, 1.38rem);
+      line-height: 1.6;
+    }
+
+    .doctrine {
+      margin: 28px 0 0;
+      padding: 16px 18px;
+      border-left: 5px solid var(--accent);
+      background: var(--accent-soft);
+      font-weight: 800;
+    }
+
+    nav {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-top: 30px;
+    }
+
+    a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 46px;
+      padding: 10px 16px;
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      color: var(--ink);
+      font-weight: 800;
+      text-decoration: none;
+    }
+
+    a.primary {
+      border-color: var(--accent);
+      background: var(--accent);
+      color: white;
+    }
+
+    a:hover { transform: translateY(-1px); }
   </style>
 </head>
 <body>
-  <div class="container">
-    <h1>Welcome to TheAVCfiles</h1>
-    <p>This is your new GitHub Pages site! 🎉</p>
-    <p>Edit <code>index.html</code> in your repository to change this content.</p>
-    
-    <h2>Daily JSONL File</h2>
-    <p>Today's data file: <a href="https://example.com/data/YYYY-MM-DD.jsonl" id="jsonl-link">YYYY-MM-DD.jsonl</a></p>
-    <p><small>The date placeholder will be automatically replaced during deployment.</small></p>
-    
-    <h2>Serverless Functions</h2>
-    <p>Try our AI-powered ask function: <a href="ask-demo.html">Ask Function Demo</a></p>
-    <p><small>Demonstrates distributed rate limiting and caching with Redis.</small></p>
-    
-    <div class="footer">
-      &copy; 2025 TheAVCfiles
-    </div>
-  </div>
-  
-  <script>
-    // Client-side date replacement as fallback
-    document.addEventListener('DOMContentLoaded', function() {
-      const today = new Date();
-      const dateStr = today.getFullYear() + '-' + 
-                     String(today.getMonth() + 1).padStart(2, '0') + '-' + 
-                     String(today.getDate()).padStart(2, '0');
-      
-      const link = document.getElementById('jsonl-link');
-      // Only replace if still contains placeholder
-      if (link.href.includes('YYYY-MM-DD')) {
-        link.href = link.href.replace('YYYY-MM-DD', dateStr);
-        link.textContent = dateStr + '.jsonl';
-      }
-    });
-  </script>
+  <main>
+    <p class="eyebrow">TheAVCfiles</p>
+    <h1>A. C. Van Cura</h1>
+    <p class="lede">
+      Systems architect, choreographer, writer, and founder building governed interfaces for movement, memory, proof, access, and value.
+    </p>
+    <p class="doctrine">The relationship explains access. The record establishes contribution.</p>
+    <nav aria-label="Primary links">
+      <a class="primary" href="evidence-of-work.html">View Evidence of Work</a>
+      <a href="https://github.com/TheAVCfiles">GitHub Profile</a>
+      <a href="https://theavcfiles.github.io/Decrypt-The-Girl/">Decrypt The Girl</a>
+    </nav>
+  </main>
 </body>
 </html>


### PR DESCRIPTION
## Purpose

Create a public, evidence-first portfolio that makes existing work legible before adding informal or third-party collaborations.

## Added

- `public/evidence-of-work.html`
  - selected public projects
  - explicit evidence links
  - clear statements of what each artifact proves
  - claim boundaries that avoid overstating employment, production readiness, ownership, or third-party outcomes
- `docs/EVIDENCE_OF_WORK.md`
  - evidence classes
  - public-claim language
  - source links
  - private evidence protocol
- refreshed `public/index.html`
  - direct entry point to the evidence portfolio
  - concise founder positioning

## Evidence featured

1. StagePort x CueR
2. StagePort CueRoom
3. StagePort PayGait
4. Holiday Activity choreographic rights management
5. Decrypt The Girl

## Governing rule

> The relationship explains access. The record establishes contribution.

## Review focus

- factual precision
- public/private boundaries
- link accuracy
- whether each claim is supported by code, commits, merged PRs, deployed demos, or documentation

This PR is intentionally draft so the public evidence package can be reviewed before publication.